### PR TITLE
Change `macos` version

### DIFF
--- a/.github/workflows/bridging.yml
+++ b/.github/workflows/bridging.yml
@@ -85,8 +85,7 @@ jobs:
       - name: Setup Google Chrome
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 130.0.6723.59
-          install-dependencies: true
+          chrome-version: stable
           install-chromedriver: true
       - name: Setup Python 3.9
         uses: actions/setup-python@v5

--- a/.github/workflows/bridging.yml
+++ b/.github/workflows/bridging.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Google Chrome
-        run: brew install --cask google-chrome@130.0.6723.59
+        run: brew install --cask google-chrome@130
       - name: Check Google Chrome version
         run: google-chrome --version
       - name: Setup Python 3.9

--- a/.github/workflows/bridging.yml
+++ b/.github/workflows/bridging.yml
@@ -82,6 +82,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Google Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 130.0.6723.59
+          install-dependencies: true
+          install-chromedriver: true
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/bridging.yml
+++ b/.github/workflows/bridging.yml
@@ -73,7 +73,7 @@ permissions:
 jobs:
   bridging:
     name: "Bridging from ${{ inputs.source }} to ${{ inputs.destination }}"
-    runs-on: macos-latest
+    runs-on: macos-13
     outputs:
       bridging_status: ${{ steps.bridging_status.outputs.bridging_status }}
       source_status: ${{ steps.bridging_status.outputs.source_status }}
@@ -82,10 +82,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Setup Google Chrome
-        run: brew install --cask google-chrome@130
-      - name: Check Google Chrome version
-        run: google-chrome --version
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/bridging.yml
+++ b/.github/workflows/bridging.yml
@@ -83,10 +83,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Google Chrome
-        uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: stable
-          install-chromedriver: true
+        run: brew install --cask google-chrome@130.0.6723.59
+      - name: Check Google Chrome version
+        run: google-chrome --version
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Currently, the `macos-latest` image comes with Google Chrome version `131.x`, which does not fully support Selenium's interaction with MetaMask. To resolve this, we switch to `macos-13`, which includes Google Chrome version `130.x`.