### PR TITLE
Refactor `find_element_by_xpath` function into `Chrome` class

### DIFF
--- a/apex_fusion_reactor.py
+++ b/apex_fusion_reactor.py
@@ -4,7 +4,7 @@ from time import sleep
 from typing import Union, Tuple
 from datetime import datetime
 from toolbox.chrome import Chrome
-from toolbox.utils import retry, find_element_by_xpath
+from toolbox.utils import retry
 from wallets.eternl import Eternl
 from wallets.metamask import MetaMask
 
@@ -40,13 +40,11 @@ class ApexFusionReactor:
     def __fund(self, receiver_address: str) -> None:
         self.__driver.get(self.__faucet_url)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="address"]'
         ).send_keys(receiver_address)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app"]/div/div[2]/main/div/div[2]/div/div/form/div[2]/button'
         ).click()
 
@@ -70,43 +68,37 @@ class ApexFusionReactor:
         # wait for the button to be available
         sleep(10)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="root"]/div[1]/div[2]/div/button'
         ).click()
 
     @retry()
     def __disconnect_wallet(self):
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="basic-button"]',
         ).click()
 
         sleep(1)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="basic-menu"]/div[3]/ul/li'
         ).click()
 
     @retry()
     def __destination_address(self, destination_address: str) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="root"]/div[1]/div[2]/div/div/div[4]/div/div[2]/div/div/input'
         ).send_keys(destination_address)
 
     @retry()
     def __amount_to_send(self, amount: str) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id=":rb:"]'
         ).send_keys(amount)
 
     @retry()
     def __set_balance(self) -> None:
-        balance = find_element_by_xpath(
-            self.__driver,
+        balance = self.__driver.find_element_by_xpath(
             '//*[@id="root"]/div[1]/div[2]/div/div/div[3]/div[1]/p'
         ).text
 
@@ -114,8 +106,7 @@ class ApexFusionReactor:
 
     @retry()
     def __send_tx(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="root"]/div[1]/div[2]/div/div/div[4]/div/div[3]/button[2]'
         ).click()
 
@@ -132,12 +123,11 @@ class ApexFusionReactor:
 
     @retry()
     def __sign_transaction(self, password: str) -> None:
-        find_element_by_xpath(
-            self.__driver, '//*[@id="password"]'
+        self.__driver.find_element_by_xpath(
+            '//*[@id="password"]'
         ).send_keys(password)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="GridFormSignWithPassword"]/button[3]'
         ).click()
 
@@ -148,8 +138,7 @@ class ApexFusionReactor:
 
     @retry()
     def __confirm_transaction(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div/div/div/div[3]/button[2]'
         ).click()
 
@@ -165,10 +154,7 @@ class ApexFusionReactor:
         tries = 200
 
         while tries > 0:
-            status = find_element_by_xpath(
-                self.__driver,
-                xpath
-            ).get_attribute('d')
+            status = self.__driver.find_element_by_xpath(xpath).get_attribute('d')
 
             if status == self.__status_done:
                 return True
@@ -199,37 +185,32 @@ class ApexFusionReactor:
         sleep(15)
 
         # filter by Destination
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="root"]/div[1]/div[2]/div/div[1]/div/div/button'
         ).click()
 
         sleep(1)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="destination-chain"]'
         ).click()
 
         sleep(1)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             f'//*[starts-with(@id, ":r")]//*[contains(text(), "{self.__destination_wallet.get_name().capitalize()}")]'
         ).click()
 
         sleep(1)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '/html/body/div[2]/div[3]/div[2]/button[2]'
         ).click()
 
         # wait the bridging history to be loaded
         sleep(15)
 
-        status = find_element_by_xpath(
-            self.__driver,
+        status = self.__driver.find_element_by_xpath(
             '//*[@id="root"]/div[1]/div[2]/div/div[2]/table/tbody/tr[1]/td[7]/div/p'
         ).text
 

--- a/toolbox/chrome.py
+++ b/toolbox/chrome.py
@@ -1,6 +1,8 @@
 from os import path
 from glob import glob
 from time import sleep
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebElement
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.chrome.webdriver import WebDriver
@@ -47,3 +49,6 @@ class Chrome(WebDriver):
 
     def get_init_tab(self) -> str:
         return self.__init_tab
+
+    def find_element_by_xpath(self, xpath: str) -> WebElement:
+        return self.find_element(By.XPATH, xpath)

--- a/toolbox/utils.py
+++ b/toolbox/utils.py
@@ -1,9 +1,6 @@
 from time import sleep
 from functools import wraps
 from dataclasses import dataclass
-from toolbox.chrome import Chrome
-from selenium.webdriver.common.by import By
-from selenium.webdriver.remote.webdriver import WebElement
 
 
 @dataclass(frozen=True)
@@ -34,7 +31,3 @@ def retry(tries: int = 10, delay: int = 1, back_off: float = 1.5):
             return f(*args, **kwargs)
         return f_retry
     return deco_retry
-
-
-def find_element_by_xpath(driver: Chrome, xpath: str) -> WebElement:
-    return driver.find_element(By.XPATH, xpath)

--- a/wallets/eternl.py
+++ b/wallets/eternl.py
@@ -1,7 +1,7 @@
 from time import sleep
 from datetime import datetime
 from toolbox.chrome import Chrome
-from toolbox.utils import retry, find_element_by_xpath
+from toolbox.utils import retry
 from selenium.common.exceptions import NoSuchElementException
 
 
@@ -26,75 +26,63 @@ class Eternl:
 
     @retry()
     def __add_wallet(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="cc-main-container"]/div/div[3]/div[1]/button'
         ).click()
 
     @retry()
     def __restore_wallet(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="cc-main-container"]/div/div[1]/div/main/div[2]/div[2]/div/div/div[1]/div[2]/button'
         ).click()
 
     @retry()
     def __recover_phrase(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="cc-main-container"]/div/div[1]/div/main/div[2]/div[2]/div/div/div[1]/div/div/div[4]/button[1]'
         ).click()
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="cc-main-container"]/div/div[1]/div/main/div[2]/div[2]/div/div/div[1]/div/div/button'
         ).click()
 
     @retry()
     def __insert_recover_phrase(self, recover_phrase: str) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="wordInput"]'
         ).send_keys(recover_phrase)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="cc-main-container"]/div/div[1]/div/main/div[2]/div[2]/div/div/div[1]/div/div/div/button[2]'
         ).click()
 
     @retry()
     def __set_wallet_name_and_sign_key(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="inputWalletName"]'
         ).send_keys(self.__name)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="password"]'
         ).send_keys(self.__sign_key)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="repeatPassword"]'
         ).send_keys(self.__sign_key)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="GridFormWalletNamePassword"]/button[3]'
         ).click()
 
     @retry()
     def __number_of_accounts(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="accountSelection"]/button[3]'
         ).click()
 
     @retry()
     def __open_wallet(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="cc-main-container"]/div/div[3]/div[2]/nav/div/div[2]/div/div'
         ).click()
 
@@ -102,13 +90,11 @@ class Eternl:
     def __set_receive_address(self) -> None:
         try:
 
-            find_element_by_xpath(
-                self.__driver,
+            self.__driver.find_element_by_xpath(
                 '//*[@id="cc-main-container"]/div/div[1]/div/main/div[1]/div/div[2]/nav/button[4]'
             ).click()
 
-            receive_address = find_element_by_xpath(
-                self.__driver,
+            receive_address = self.__driver.find_element_by_xpath(
                 '//*[@id="cc-main-container"]/div/div[1]/div/main/div[2]/div[2]/div/div/div[1]/div[4]/div[1]/div/div'
             )
 
@@ -121,8 +107,7 @@ class Eternl:
 
     @retry()
     def __set_balance(self) -> None:
-        balance = find_element_by_xpath(
-            self.__driver,
+        balance = self.__driver.find_element_by_xpath(
             '//*[@id="cc-main-container"]/div/div[1]/div/main/div[1]/div/div[1]/div/div[1]/div[2]/div[2]'
         ).text
 
@@ -157,13 +142,11 @@ class Eternl:
     def toggle(self) -> None:
         self.__driver.get(self.__url)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="cc-main-container"]/div/div[3]/div[2]/nav/div/div[2]/div'
         ).click()
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="cc-main-container"]/div/div[1]/div/main/div[1]/div/div[1]/div/div[3]'
         ).click()
 
@@ -173,8 +156,7 @@ class Eternl:
 
         self.__driver.switch_to.window(popup)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="cc-main-container"]/div/div/div/main/div/div[2]/button[2]'
         ).click()
 

--- a/wallets/metamask.py
+++ b/wallets/metamask.py
@@ -1,7 +1,7 @@
 from time import sleep
 from datetime import datetime
 from toolbox.chrome import Chrome
-from toolbox.utils import retry, find_element_by_xpath
+from toolbox.utils import retry
 
 
 class MetaMask:
@@ -25,22 +25,19 @@ class MetaMask:
 
     @retry()
     def __agree_terms(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="onboarding__terms-checkbox"]'
         ).click()
 
     @retry()
     def __import_wallet(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div/div/ul/li[3]/button'
         ).click()
 
     @retry()
     def __no_improve(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div/div/div[2]/button[1]'
         ).click()
 
@@ -50,63 +47,53 @@ class MetaMask:
 
         for i in range(len(phrase)):
 
-            find_element_by_xpath(
-                self.__driver,
+            self.__driver.find_element_by_xpath(
                 f'//*[@id="import-srp__srp-word-{i}"]'
             ).send_keys(phrase[i])
 
     @retry()
     def __confirm_phrase(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div/div/div[4]/div/button'
         ).click()
 
     @retry()
     def __set_sign_key(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div/div/div[2]/form/div[1]/label/input'
         ).send_keys(self.__sign_key)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div/div/div[2]/form/div[2]/label/input'
         ).send_keys(self.__sign_key)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div/div/div[2]/form/div[3]/label/span[1]/input'
         ).click()
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div/div/div[2]/form/button'
         ).click()
 
     @retry()
     def __unlock(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="password"]'
         ).send_keys(self.__sign_key)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[3]/div/div/div/div/button'
         ).click()
 
     @retry()
     def __got_it(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div/div/div[2]/button'
         ).click()
 
     @retry()
     def __finish(self) -> None:
-        bnt = find_element_by_xpath(
-            self.__driver,
+        bnt = self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div/div/div[2]/button'
         )
 
@@ -117,13 +104,11 @@ class MetaMask:
 
     @retry()
     def __set_balance(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[3]/div/div/div/div[2]/div/div/div/div[1]/a'
         ).click()
 
-        balance = find_element_by_xpath(
-            self.__driver,
+        balance = self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[3]/div/div/div[3]/div[1]/div/div[2]/div[1]/div[2]/p[2]',
         ).text
 
@@ -131,18 +116,15 @@ class MetaMask:
 
     @retry()
     def __set_receive_address(self) -> None:
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div[3]/div/div/button'
         ).click()
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[2]/div/div[3]/div[2]/button[2]'
         ).click()
 
-        self.__receive_address = find_element_by_xpath(
-            self.__driver,
+        self.__receive_address = self.__driver.find_element_by_xpath(
             '/html/body/div[3]/div[3]/div/section/div/div/div[2]/p'
         ).text
 
@@ -178,35 +160,29 @@ class MetaMask:
 
         sleep(5)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[3]/div/div[2]/div[2]/div/div[2]/div/div[1]/div[2]/div[1]/div/input'
         ).send_keys(name)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[3]/div/div[2]/div[2]/div/div[2]/div/div[1]/div[2]/div[2]/label/input'
         ).send_keys(rpc_url)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[3]/div/div[2]/div[2]/div/div[2]/div/div[1]/div[2]/div[3]/div/input'
         ).send_keys(chain_id)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[3]/div/div[2]/div[2]/div/div[2]/div/div[1]/div[2]/div[4]/div/input'
         ).send_keys(currency_symbol)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="app-content"]/div/div[3]/div/div[2]/div[2]/div/div[2]/div/div[2]/button[2]'
         ).click()
 
         sleep(1)
 
-        find_element_by_xpath(
-            self.__driver,
+        self.__driver.find_element_by_xpath(
             '//*[@id="popover-content"]/div/div/section/div[2]/div/button[1]'
         ).click()
 
@@ -228,8 +204,7 @@ class MetaMask:
 
         for i in range(2):
 
-            find_element_by_xpath(
-                self.__driver,
+            self.__driver.find_element_by_xpath(
                 '//*[@id="app-content"]/div/div/div/div[3]/div[2]/footer/button[2]'
             ).click()
 


### PR DESCRIPTION
This PR refactors the `find_element_by_xpath` function, implementing it into the Chrome class. This change enhances the modularity and encapsulation of the codebase by ensuring the method is directly tied to the browser instance it operates on.